### PR TITLE
When adding an event listener using `once`, node wraps it with a func…

### DIFF
--- a/src/plugins/node/index.js
+++ b/src/plugins/node/index.js
@@ -45,6 +45,10 @@ export const patch = () => {
       return ret;
     }
 
+    if (handler.listener) {
+      computation.listener = handler.listener;
+    }
+
     computationMap.set(handler, computation);
     listenerMap.set(computation, handler);
     const dispose = () => {


### PR DESCRIPTION
…tion and adds a `listener` property on that function to reference the original handler.

When trying to remove that listener, node uses the `listener` reference to compare it to the given listener argument.
Since `computation` wraps that wrapper and is missing the `listener` reference it ends up not being removed.
This fix adds that reference if it exists.